### PR TITLE
Added support for disabling referrals

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,6 +20,7 @@ class Configuration implements ConfigurationInterface
               ->scalarNode('version')->end()
               ->scalarNode('username')->end()
               ->scalarNode('password')->end()
+              ->scalarNode('referrals_enabled')->end()
             ->end()
           ->end()
           ->arrayNode('user')

--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -115,6 +115,10 @@ class LdapConnection implements LdapConnectionInterface
         if (isset($this->params['client']['version']) && $this->params['client']['version'] !== null) {
             ldap_set_option($ress, LDAP_OPT_PROTOCOL_VERSION, $this->params['client']['version']);
         }
+        
+        if (isset($this->params['client']['referrals_enabled']) && $this->params['client']['referrals_enabled'] !== null) {
+            ldap_set_option($ress, LDAP_OPT_REFERRALS, $this->params['client']['referrals_enabled']);
+        }
 
         if (isset($this->params['client']['username']) && $this->params['client']['version'] !== null) {
             if(!isset($this->params['client']['password'])) {


### PR DESCRIPTION
I had some problems using the bundle with Windows Server 2003 - according to this comment on php.net (http://www.php.net/manual/en/function.ldap-search.php#45388) an option must be set to allow searching from the root of the AD schema. I've added an option to the bundle's config to manipulate this setting.
