### PR TITLE
Throw a runtime exception php ldap module not available

### DIFF
--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -110,6 +110,10 @@ class LdapConnection implements LdapConnectionInterface
             ? $this->params['client']['port'] 
             : '389';
 
+        if (!function_exists('ldap_connect')) {
+            throw new \RuntimeException("IMAGLdapBundle requires php ldap support");
+        }
+
         $ress = @ldap_connect($this->params['client']['host'], $port);
 
         if (isset($this->params['client']['version']) && $this->params['client']['version'] !== null) {


### PR DESCRIPTION
Since the ldap_connect function is @ surpressed, PHP didn't throw any fatal errors for me when I tried to call this, and I got a white screen that took forever for me to track down the error.

This should make it much more easy for people to easily realize their environment doesn't have php-ldap module installed.
