### PR TITLE
Vac

### DIFF
--- a/User/LdapUser.php
+++ b/User/LdapUser.php
@@ -102,7 +102,7 @@ class LdapUser implements UserInterface, \Serializable
         if ($user->getEmail() !== $this->email) {
             return false;
         }
-        if ($user->getRoles() !== $this->roles) {
+        if (count( array_diff( $user->getRoles(), $this->roles) ) > 0 ) {
             return false;
         }
         if ($user->getDn() !== $this->dn) {


### PR DESCRIPTION
2 changes here.

One adds escaping in ldap_search filters, so things like dn=Cooper\, Andrew,... can be properly searched.

The other change modifies the criteria for equality of the roles of an LdapUser. The results of an ldap_search for group membership are not in a guaranteed order so a plain equality test on the arrays isn't sufficient.
