### PR TITLE
Fix issue where filter input from userland or other queries is not escap...

### DIFF
--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -162,4 +162,23 @@ class LdapConnection implements LdapConnectionInterface
             ->err($message);
     }
 
+    /**
+     * Escape string for use in LDAP search filter.
+     *
+     * @link http://www.php.net/manual/de/function.ldap-search.php#90158
+     * See RFC2254 for more information.
+     * @link http://msdn.microsoft.com/en-us/library/ms675768(VS.85).aspx
+     * @link http://www-03.ibm.com/systems/i/software/ldap/underdn.html
+     */
+    public function escape($str)
+    {
+        $metaChars = array('*', '(', ')', '\\', chr(0));
+
+        $quotedMetaChars = array();
+        foreach ($metaChars as $key => $value) {
+            $quotedMetaChars[$key] = '\\'.str_pad(dechex(ord($value)), 2, '0');
+        }
+        $str = str_replace($metaChars, $quotedMetaChars, $str);
+        return ($str);
+    }
 }

--- a/Manager/LdapManagerUser.php
+++ b/Manager/LdapManagerUser.php
@@ -66,6 +66,10 @@ class LdapManagerUser implements LdapManagerUserInterface
 
     public function setUsername($username)
     {
+        if ($username === "*") {
+            throw new \InvalidArgumentException("Invalid username given.");
+        }
+
         $this->username = $username;
 
         return $this;
@@ -94,7 +98,8 @@ class LdapManagerUser implements LdapManagerUserInterface
                 'filter' => sprintf('(&%s(%s=%s))', 
                                     $filter,
                                     $this->params['user']['name_attribute'],
-                                    $this->username)
+                                    $this->ldapConnection->escape($this->username)
+                                  )
             ));
 
         if ($entries['count'] > 1) {
@@ -128,7 +133,8 @@ class LdapManagerUser implements LdapManagerUserInterface
                 'filter'   => sprintf('(&%s(%s=%s))', 
                                       $filter,
                                       $this->params['role']['user_attribute'],
-                                      $this->getUserId()),
+                                      $this->ldapConnection->escape($this->getUserId())
+                ),
                 'attrs'    => array(
                     $this->params['role']['name_attribute']
                 )


### PR DESCRIPTION
...ed in ldap_search().

This may in rare cases be a security issue when LDAP only returns exactly one user even on queries for "*" it may lead to disclosure of information, however i think through the way ldap_bind is used this cannot become a security issue to login arbitrary users without authentication.
