### PR TITLE
User attribute support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,7 +28,7 @@ class Configuration implements ConfigurationInterface
               ->scalarNode('base_dn')->isRequired()->cannotBeEmpty()->end()
               ->scalarNode('filter')->end()
               ->scalarNode('name_attribute')->defaultValue('uid')->end()
-              ->arrayNode('attributes')->defaultValue(array())->end()
+              ->arrayNode('attributes')->defaultValue(array())->ignoreExtraKeys(true)->end()
             ->end()
           ->end()
           ->arrayNode('role')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,7 @@ class Configuration implements ConfigurationInterface
               ->scalarNode('base_dn')->isRequired()->cannotBeEmpty()->end()
               ->scalarNode('filter')->end()
               ->scalarNode('name_attribute')->defaultValue('uid')->end()
+              ->arrayNode('attributes')->defaultValue(array())->end()
             ->end()
           ->end()
           ->arrayNode('role')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,7 +28,7 @@ class Configuration implements ConfigurationInterface
               ->scalarNode('base_dn')->isRequired()->cannotBeEmpty()->end()
               ->scalarNode('filter')->end()
               ->scalarNode('name_attribute')->defaultValue('uid')->end()
-              ->arrayNode('attributes')->defaultValue(array())->ignoreExtraKeys(true)->end()
+              ->variableNode('attributes')->defaultValue(array())->end()
             ->end()
           ->end()
           ->arrayNode('role')

--- a/Manager/LdapManagerUser.php
+++ b/Manager/LdapManagerUser.php
@@ -54,6 +54,17 @@ class LdapManagerUser implements LdapManagerUserInterface
         return $this->_ldapUser['mail'][0];
     }
 
+    public function getAttributes()
+    {
+        $attributes = array();
+        foreach ($this->params['user']['attributes'] as $attrName) {
+            if (isset($this->_ldapUser[$attrName][0])) {
+                $attributes[$attrName] = $this->_ldapUser[$attrName][0];
+            }
+        }
+        return $attributes;
+    }
+
     public function getUsername()
     {
         return $this->username;

--- a/Provider/LdapUserProvider.php
+++ b/Provider/LdapUserProvider.php
@@ -33,7 +33,9 @@ class LdapUserProvider implements UserProviderInterface
       ->setUsername($lm->getUsername())
       ->setEmail($lm->getEmail())
       ->setRoles($lm->getRoles())
-      ->setDn($lm->getDn());
+      ->setDn($lm->getDn())
+      ->setAttributes($lm->getAttributes())
+     ;
 
     return $ldapUser;
   }

--- a/User/LdapUser.php
+++ b/User/LdapUser.php
@@ -10,7 +10,8 @@ class LdapUser implements UserInterface, \Serializable
         $username,
         $email,
         $roles,
-        $dn;
+        $dn,
+        $attributes;
 
     public function getRoles()
     {
@@ -48,6 +49,19 @@ class LdapUser implements UserInterface, \Serializable
         $this->dn = $dn;
 
         return $this;
+    }
+
+    public function setAttributes(array $attributes)
+    {
+        $this->attributes = $attributes;
+    }
+
+    public function getAttribute($name)
+    {
+        if (isset($this->attributes[$name])) {
+            return $this->attributes[$name];
+        }
+        return null;
     }
 
     public function setUsername($username)


### PR DESCRIPTION
This PR adds support to put additional attributes on the LdapUser by means of configuration.

```
imag_ldap:
  user:
    attributes: ["foo", "bar", "baz"]
```
