### PR TITLE
Credentials aren't serialized in the Token

### DIFF
--- a/Authentication/Token/LdapToken.php
+++ b/Authentication/Token/LdapToken.php
@@ -6,21 +6,19 @@ use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 
 class LdapToken extends AbstractToken
 {
-  private 
-    $credentials;
 
   public function __construct($username, $password, array $roles= array())
   {
     parent::__construct($roles);
 
     $this->setuser($username);
-    $this->credentials = $password;
+    $this->setAttribute('credentials', $password);
   }
 
   public function getCredentials()
   {
-    return $this->credentials;
+    return $this->getAttribute('credentials');
   }
 
-  
+
 }


### PR DESCRIPTION
Since the `LdapAuthenticationProvider->bind` method requires the token to have credentials, it fails because the serialized version of the Token does NOT have credentials inside it.
