### PR TITLE
Compare roles with array_diff

### DIFF
--- a/User/LdapUser.php
+++ b/User/LdapUser.php
@@ -102,7 +102,7 @@ class LdapUser implements UserInterface, \Serializable
         if ($user->getEmail() !== $this->email) {
             return false;
         }
-        if ($user->getRoles() !== $this->roles) {
+        if (count( array_diff( $user->getRoles(), $this->roles) ) > 0 ) {
             return false;
         }
         if ($user->getDn() !== $this->dn) {


### PR DESCRIPTION
The order of roles returned by the ldap server may not be guaranteed,
so compare them irrespective of order.
