### PR TITLE
Extendable/configurable LdapUser class

### DIFF
--- a/Resources/config/security_ldap.xml
+++ b/Resources/config/security_ldap.xml
@@ -4,6 +4,7 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <parameters>
+    <parameter key="imag_ldap.security.user.class">IMAG\LdapBundle\User\LdapUser</parameter>
     <parameter key="imag_ldap.security.user.provider.class">IMAG\LdapBundle\Provider\LdapUserProvider</parameter>
     <parameter key="imag_ldap.ldap_connection.class">IMAG\LdapBundle\Manager\LdapConnection</parameter>
     <parameter key="imag_ldap.ldap_manager.class">IMAG\LdapBundle\Manager\LdapManagerUser</parameter>
@@ -24,6 +25,7 @@
 
     <service id="imag_ldap.security.user.provider" class="%imag_ldap.security.user.provider.class%">
       <argument type="service" id="imag_ldap.ldap_manager" />
+      <argument>%imag_ldap.security.user.class%</argument>
     </service>
 
     <service id="imag_ldap.ldap_connection" class="%imag_ldap.ldap_connection.class%" public="false">


### PR DESCRIPTION
Hi Boris,

I'm using your LdapBundle, which works great, but I wanted to extend the LdapUser class. This didn't seem possible because the LdapUser class was hardcoded in the LdapUserProvider.

In this pull request I made the LdapUser class configurable by passing it as an argument to the LdapUserProvider service. Now it's possible to set the value in `config/parameters.ini`:

`imag_ldap.security.user.class = "Fieg\Bundle\AcmeBundle\Entity\User"`

The `Fieg\Bundle\AcmeBundle\Entity\User` class extends the `IMAG\LdapBundle\User\LdapUser` class.
