### PR TITLE
Patch

### DIFF
--- a/Manager/LdapManagerUser.php
+++ b/Manager/LdapManagerUser.php
@@ -30,20 +30,12 @@ class LdapManagerUser implements LdapManagerUserInterface
 
     public function auth()
     {
-        return (bool) $this
-            ->doPass()
-            ->bind()
-            ;
+        return (bool) ($this->doPass() && $this->bind());
     }
 
     public function doPass()
     {
-        $this
-            ->addLdapUser()
-            ->addLdapRoles()
-            ;
-
-        return $this;
+        return $this->addLdapUser() && $this->addLdapRoles() ? $this : false;
     }
 
     public function getDn()

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "imag/ldapbundle",
+    "name": "imag/ldap-bundle",
     "description": "LDAP Bundle for Symfony 2",
     "homepage": "http://github.com/BorisMorel/LdapBundle",
     "version": "1.2",


### PR DESCRIPTION
- follow Packagist naming convention, http://packagist.org/about    1848328
- fix fatal error when using chained providers (e.g., in-memory + ldap) and attempting to authenticate with a non-ldap user and no password
