### PR TITLE
add support for setting LDAP_OPT_NETWORK_TIMEOUT

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -21,6 +21,7 @@ class Configuration implements ConfigurationInterface
               ->scalarNode('username')->end()
               ->scalarNode('password')->end()
               ->scalarNode('referrals_enabled')->end()
+              ->scalarNode('network_timeout')->end()
             ->end()
           ->end()
           ->arrayNode('user')

--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -48,6 +48,8 @@ class LdapConnection implements LdapConnectionInterface
         if ($search) {
             $entries = ldap_get_entries($this->_ress, $search);
 
+            @ldap_free_result($this->_ress);
+
             return is_array($entries) ? $entries : false;
         }
 
@@ -107,15 +109,19 @@ class LdapConnection implements LdapConnectionInterface
 
         $ress = @ldap_connect($this->params['client']['host'], $port);
 
-        if (isset($this->params['client']['version']) && $this->params['client']['version'] !== null) {
+        if (isset($this->params['client']['version'])) {
             ldap_set_option($ress, LDAP_OPT_PROTOCOL_VERSION, $this->params['client']['version']);
         }
 
-        if (isset($this->params['client']['referrals_enabled']) && $this->params['client']['referrals_enabled'] !== null) {
+        if (isset($this->params['client']['referrals_enabled'])) {
             ldap_set_option($ress, LDAP_OPT_REFERRALS, $this->params['client']['referrals_enabled']);
         }
 
-        if (isset($this->params['client']['username']) && $this->params['client']['version'] !== null) {
+        if (isset($this->params['client']['network_timeout'])) {
+            ldap_set_option($ress, LDAP_OPT_NETWORK_TIMEOUT, $this->params['client']['network_timeout']);
+        }
+
+        if (isset($this->params['client']['username'])) {
             if (!isset($this->params['client']['password'])) {
                 throw new \Exception('You must uncomment password key');
             }


### PR DESCRIPTION
this can prevent ldap_search() from blocking indefinitely under poor network conditions (e.g., local VM -> VPN over Wi-Fi + ADSL -> cloud VM)

Also:
- free result when done with it
- remove redundant "!== null" checks already implied by isset()
