### PR TITLE
Allow binding with username before loading user

### DIFF
--- a/Manager/LdapManagerUser.php
+++ b/Manager/LdapManagerUser.php
@@ -33,6 +33,11 @@ class LdapManagerUser implements LdapManagerUserInterface
         return (bool) ($this->doPass() && $this->bind());
     }
 
+    public function authNoAnonSearch()
+    {
+        return (bool) ($this->bindUser() && $this->doPass());
+    }
+
     public function doPass()
     {
         return $this->addLdapUser() && $this->addLdapRoles() ? $this : false;
@@ -160,6 +165,12 @@ class LdapManagerUser implements LdapManagerUserInterface
     {
         return $this->ldapConnection
             ->bind($this->_ldapUser['dn'], $this->password);
+    }
+
+    private function bindUser()
+    {
+        return $this->ldapConnection
+            ->bind($this->username, $this->password);
     }
 
     private static function slugify($role)

--- a/Manager/LdapManagerUserInterface.php
+++ b/Manager/LdapManagerUserInterface.php
@@ -7,6 +7,7 @@ interface LdapManagerUserInterface
   function __construct(LdapConnectionInterface $conn);
   function exists($username);
   function auth();
+  function authNoAnonSearch();
   function doPass();
   function getDn();
   function getEmail();

--- a/Provider/LdapAuthenticationProvider.php
+++ b/Provider/LdapAuthenticationProvider.php
@@ -37,8 +37,10 @@ class LdapAuthenticationProvider implements AuthenticationProviderInterface
      *
      * @param UserProviderInterface    $userProvider
      * @param LdapManagerUserInterface $ldapManager
+     * @param EventDispatcherInterface $dispatcher
      * @param string                   $providerKey
      * @param Boolean                  $hideUserNotFoundExceptions
+     * @param Boolean                  $anonSearchAllowed
      */
     public function __construct(
         UserProviderInterface $userProvider,

--- a/Resources/config/security_ldap.xml
+++ b/Resources/config/security_ldap.xml
@@ -43,6 +43,7 @@
       <argument type="service" id="event_dispatcher" on-invalid="null" />
       <argument /> <!-- Provider-key -->
       <argument /> <!-- hide exception -->
+      <argument /> <!-- Anon auth allowed -->
     </service>
 
     <service id="imag_ldap.security.authentication.listener"


### PR DESCRIPTION
anonymous searches and where user credentials are not provided.
- Added parameter to Authentication provider to bind with
  user credentials before loading user and roles
- Added alternative auth method to user interface that will
  bind user before loading user and roles
- Added alternative bind method to user inferface that will
  bind with username from form rather than loaded DN
