### PR TITLE
Removed 'source' from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,6 @@
         "php": ">=5.3.3",
         "symfony/symfony": ">2.0"
     },
-    "source": {
-        "url": "https://github.com/BorisMorel/LdapBundle.git",
-        "type": "git",
-        "reference": "origin/master"
-    },
     "autoload": {
         "psr-0": { "IMAG\\LdapBundle": "" }
     },


### PR DESCRIPTION
The "source" key is not needed in composer.json. 
Having it there breaks the ability to reference different branches in composer.json in the projects, which require this bundle.
