### PR TITLE
Only connect to LDAP server when attempting to interact with server

### DIFF
--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -16,11 +16,12 @@ class LdapConnection implements LdapConnectionInterface
     {
         $this->params = $params;
         $this->logger = $logger;
-        $this->connect();
     }
 
     public function search(array $params)
     {
+        $this->connect();
+
         $ref = array(
             'base_dn' => '',
             'filter' => '',
@@ -61,6 +62,8 @@ class LdapConnection implements LdapConnectionInterface
         if (empty($user_dn) || ! is_string($user_dn)) {
             throw new ConnectionException("LDAP user's DN (user_dn) must be provided (as a string).");
         }
+
+        $this->connect();
 
         // According to the LDAP RFC 4510-4511, the password can be blank.
         return @ldap_bind($this->ress, $user_dn, $password);
@@ -103,6 +106,10 @@ class LdapConnection implements LdapConnectionInterface
 
     private function connect()
     {
+        if (null != $this->ress && false !== $this->ress) {
+            return $this;
+        }
+
         $port = isset($this->params['client']['port'])
             ? $this->params['client']['port']
             : '389';


### PR DESCRIPTION
This attempts to fix the issue @lngphp was having in the comments of #53.

I also ran into the same problem when developing offline (no internet connection) and relying on a remote LDAP server for my authentication. When attempting to clear the cache and being offline would would throw this Exception:

```
The credentials you have configured are not valid
```

Instead, I have moved the connection code from the `LdapConnection::__construct()` into each method that actually queries against the LDAP server. This also now checks if a valid connection resource and returns early if a connection has already been previously made.

As a side note, I don't feel the error message above accurately describe the problem. The problem was the connection to the server could not be made--not that my credentials were invalid. This error is not thrown until attempting to [bind to the server](https://github.com/BorisMorel/LdapBundle/blob/ca21a5c5c2931e6c0bc383336b1662a892c4d086/Manager/LdapConnection.php#L131). Why not check if `ldap_connect()` [returns false](https://github.com/BorisMorel/LdapBundle/blob/ca21a5c5c2931e6c0bc383336b1662a892c4d086/Manager/LdapConnection.php#L110) and throw an Exception if unable to connect?

If you would like me to add a check for failed connection and throw an Exception I can add code to this PR.

Thanks!
:rocket: 
