### PR TITLE
Added array initializations in LdapUser

### DIFF
--- a/User/LdapUser.php
+++ b/User/LdapUser.php
@@ -9,9 +9,9 @@ class LdapUser implements UserInterface, EquatableInterface, \Serializable
 {
     protected $username,
         $email,
-        $roles,
+        $roles = array(),
         $dn,
-        $attributes
+        $attributes = array()
         ;
 
     public function getRoles()


### PR DESCRIPTION
These attributes should always be an array.
