### PR TITLE
Use an interface to define the structure of the LdapUser object

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -16,10 +16,13 @@ class Configuration implements ConfigurationInterface
             ->append($this->addClientNode())
             ->append($this->addUserNode())
             ->append($this->addRoleNode())
+            ->scalarNode('user_class')
+              ->defaultValue("IMAG\LdapBundle\User\LdapUser")
+            ->end()
         ->end()
         ;
 
-    return $treeBuilder;      
+    return $treeBuilder;
   }
 
   private function addClientNode()
@@ -38,7 +41,7 @@ class Configuration implements ConfigurationInterface
               ->booleanNode('bind_username_before')->defaultFalse()->end()
               ->scalarNode('referrals_enabled')->end()
               ->scalarNode('network_timeout')->end()
-              ->booleanNode('skip_roles')->defaultFalse()->end()          
+              ->booleanNode('skip_roles')->defaultFalse()->end()
            ->end()
           ;
 
@@ -85,4 +88,5 @@ class Configuration implements ConfigurationInterface
 
       return $node;
   }
+
 }

--- a/DependencyInjection/IMAGLdapExtension.php
+++ b/DependencyInjection/IMAGLdapExtension.php
@@ -20,6 +20,7 @@ class IMAGLdapExtension extends Extension
 
         $container->setParameter('imag_ldap.ldap_connection.params', $config);
         $container->setParameter('imag_ldap.authentication.bind_username_before', $config['client']['bind_username_before']);
+        $container->setParameter('imag_ldap.model.user_class', $config["user_class"]);
     }
 
     public function getAlias()

--- a/Event/LdapUserEvent.php
+++ b/Event/LdapUserEvent.php
@@ -4,13 +4,13 @@ namespace IMAG\LdapBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
 
-use IMAG\LdapBundle\User\LdapUser;
+use IMAG\LdapBundle\User\LdapUserInterface;
 
 class LdapUserEvent extends Event
-{ 
+{
     private $user;
 
-    public function __construct(LdapUser $user)
+    public function __construct(LdapUserInterface $user)
     {
         $this->user = $user;
     }

--- a/Provider/LdapAuthenticationProvider.php
+++ b/Provider/LdapAuthenticationProvider.php
@@ -16,7 +16,7 @@ use IMAG\LdapBundle\Authentication\Token\LdapToken;
 use IMAG\LdapBundle\Manager\LdapManagerUserInterface;
 use IMAG\LdapBundle\Event\LdapUserEvent;
 use IMAG\LdapBundle\Event\LdapEvents;
-use IMAG\LdapBundle\User\LdapUser;
+use IMAG\LdapBundle\User\LdapUserInterface;
 
 class LdapAuthenticationProvider implements AuthenticationProviderInterface
 {
@@ -77,7 +77,7 @@ class LdapAuthenticationProvider implements AuthenticationProviderInterface
             throw $userNotFoundException;
         }
 
-        if ($user instanceof LdapUser) {
+        if ($user instanceof LdapUserInterface) {
             if (null !== $this->dispatcher) {
                 $userEvent = new LdapUserEvent($user);
                 try {
@@ -118,12 +118,12 @@ class LdapAuthenticationProvider implements AuthenticationProviderInterface
     /**
      * Authenticate the user with LDAP bind.
      *
-     * @param \IMAG\LdapBundle\User\LdapUser  $user
+     * @param \IMAG\LdapBundle\User\LdapUserInterface  $user
      * @param TokenInterface $token
      *
      * @return boolean
      */
-    private function bind(LdapUser $user, TokenInterface $token)
+    private function bind(LdapUserInterface $user, TokenInterface $token)
     {
         $this->ldapManager
             ->setUsername($user->getUsername())
@@ -135,10 +135,10 @@ class LdapAuthenticationProvider implements AuthenticationProviderInterface
     /**
      * Reload user with the username
      *
-     * @param \IMAG\LdapBundle\User\LdapUser $user
-     * @return \IMAG\LdapBundle\User\LdapUser $user
+     * @param \IMAG\LdapBundle\User\LdapUserInterface $user
+     * @return \IMAG\LdapBundle\User\LdapUserInterface $user
      */
-    private function reloadUser(LdapUser $user)
+    private function reloadUser(LdapUserInterface $user)
     {
         try {
             $user = $this->userProvider->refreshUser($user);

--- a/Provider/LdapUserProvider.php
+++ b/Provider/LdapUserProvider.php
@@ -30,15 +30,22 @@ class LdapUserProvider implements UserProviderInterface
     private $bindUsernameBefore;
 
     /**
+     * The class name of the User model
+     * @var string
+     */
+    private $userClass;
+
+    /**
      * Constructor
      *
      * @param \IMAG\LdapBundle\Manager\LdapManagerUserInterface $ldapManager
      * @param string $bindUsernameBefore
      */
-    public function __construct(LdapManagerUserInterface $ldapManager, $bindUsernameBefore = false)
+    public function __construct(LdapManagerUserInterface $ldapManager, $bindUsernameBefore = false, $userClass)
     {
         $this->ldapManager = $ldapManager;
         $this->bindUsernameBefore = $bindUsernameBefore;
+        $this->userClass = $userClass;
     }
 
     /**

--- a/Provider/LdapUserProvider.php
+++ b/Provider/LdapUserProvider.php
@@ -8,8 +8,7 @@ use Symfony\Component\Security\Core\Exception\UnsupportedUserException,
     Symfony\Component\Security\Core\User\UserProviderInterface;
 
 use IMAG\LdapBundle\Manager\LdapManagerUserInterface,
-    IMAG\LdapBundle\User\LdapUserInterface,
-    IMAG\LdapBundle\User\LdapUser;
+    IMAG\LdapBundle\User\LdapUserInterface;
 
 /**
  * LDAP User Provider
@@ -89,7 +88,7 @@ class LdapUserProvider implements UserProviderInterface
 
     private function simpleUser($username)
     {
-        $ldapUser = new LdapUser();
+        $ldapUser = new $this->userClass;
         $ldapUser->setUsername($username);
 
         return $ldapUser;
@@ -106,7 +105,7 @@ class LdapUserProvider implements UserProviderInterface
             ->setUsername($username)
             ->doPass();
 
-        $ldapUser = new LdapUser();
+        $ldapUser = new $this->userClass;
 
         $ldapUser
             ->setUsername($lm->getUsername())

--- a/Provider/LdapUserProvider.php
+++ b/Provider/LdapUserProvider.php
@@ -8,6 +8,7 @@ use Symfony\Component\Security\Core\Exception\UnsupportedUserException,
     Symfony\Component\Security\Core\User\UserProviderInterface;
 
 use IMAG\LdapBundle\Manager\LdapManagerUserInterface,
+    IMAG\LdapBundle\User\LdapUserInterface,
     IMAG\LdapBundle\User\LdapUser;
 
 /**
@@ -55,7 +56,7 @@ class LdapUserProvider implements UserProviderInterface
         } else {
             $ldapUser = $this->anonymousSearch($username);
         }
-        
+
         return $ldapUser;
     }
 
@@ -64,7 +65,7 @@ class LdapUserProvider implements UserProviderInterface
      */
     public function refreshUser(UserInterface $user)
     {
-        if (!$user instanceof LdapUser) {
+        if (!$user instanceof LdapUserInterface) {
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_class($user)));
         }
 
@@ -76,7 +77,7 @@ class LdapUserProvider implements UserProviderInterface
      */
     public function supportsClass($class)
     {
-        return $class === 'IMAG\LdapBundle\User\LdapUser';
+        return ($class instanceof LdapUserInterface);
     }
 
     private function simpleUser($username)
@@ -106,7 +107,7 @@ class LdapUserProvider implements UserProviderInterface
             ->setRoles($lm->getRoles())
             ->setDn($lm->getDn())
             ->setAttributes($lm->getAttributes())
-            ;        
+            ;
 
         return $ldapUser;
     }

--- a/Resources/Docs/ldap_with_custom_user_manager.md
+++ b/Resources/Docs/ldap_with_custom_user_manager.md
@@ -1,0 +1,283 @@
+Using a custom user manager with LDAP authentication
+========================
+
+One does not need to rely on having a full-fledged user entity in the LDAP
+directory. It is not so uncommon to use the directories as authentication-only
+services (e.g. because of organizational restrictions), but needed user
+attributes have to be stored somewhere else. The following example
+uses the user manager provided by the [FOSUserBundle](https://github.com/FriendsOfSymfony/FOSUserBundle), but basically any
+solution can be used. A configured and working FOSUserBundle instance is assumed
+for the rest of this documentation.
+
+### Create a User entity
+
+First a user entity implementing the necessary interfaces needs to be created
+and customized:
+
+```php
+<?php
+// src/Acme/DemoBundle/Entity/User.php
+
+namespace Acme\DemoBundle\Entity;
+
+use FOS\UserBundle\Entity\User as BaseUser;
+use Doctrine\ORM\Mapping as ORM;
+use IMAG\LdapBundle\User\LdapUserInterface;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="fos_user")
+ */
+class User extends BaseUser implements LdapUserInterface
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(name="dn", type="string", length=255)
+     */
+    protected $dn;
+
+
+    protected $attributes;
+
+    public function __construct()
+    {
+        parent::__construct();
+        // your own logic
+    }
+
+    public function getDn()
+    {
+        return $this->dn;
+    }
+
+    public function setDn($dn)
+    {
+        $this->dn = $dn;
+
+        return $this;
+    }
+
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    public function setAttributes(array $attributes)
+    {
+        $this->attributes = $attributes;
+
+        return $this;
+    }
+
+    public function getAttribute($name)
+    {
+        return isset($this->attributes[$name]) ? $this->attributes[$name] : null;
+    }
+
+    public function isEqualTo(UserInterface $user)
+    {
+        if (!$user instanceof LdapUserInterface
+            || $user->getUsername() !== $this->username
+            || $user->getEmail() !== $this->email
+            || count(array_diff($user->getRoles(), $this->getRoles())) > 0
+            || $user->getDn() !== $this->dn
+        ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function serialize()
+    {
+        return serialize(array(
+            $this->password,
+            $this->salt,
+            $this->usernameCanonical,
+            $this->username,
+            $this->emailCanonical,
+            $this->email,
+            $this->expired,
+            $this->locked,
+            $this->credentialsExpired,
+            $this->enabled,
+            $this->id,
+            $this->roles,
+            $this->dn,
+        ));
+    }
+
+    public function unserialize($serialized)
+    {
+        list(
+            $this->password,
+            $this->salt,
+            $this->usernameCanonical,
+            $this->username,
+            $this->emailCanonical,
+            $this->email,
+            $this->expired,
+            $this->locked,
+            $this->credentialsExpired,
+            $this->enabled,
+            $this->id,
+            $this->roles,
+            $this->dn,
+        ) = unserialize($serialized);
+    }
+
+}
+```
+As this user model extends the FOSUserBundle base user model, the serialization
+and equality functions are overriden to accomodate the need of the distinguished
+name (`$dn`).
+
+### Update configuration
+
+The generated and configured user entity needs to be registered in the configuration (`config.yml`):
+```yml
+imag_ldap:
+  client:
+    host: your.host.foo
+    port: 389
+
+  user:
+    base_dn: ou=people, dc=host, dc=foo
+    name_attribute: uid
+
+  user_class: Acme\DemoBundle\Entity\User
+```
+
+### Create custom user provider service
+
+Now all that's left is the creation of a custom `LdapUserProvider` service that
+handles the creation and population of the user entity during requests:
+```php
+<?php
+
+namespace Acme\DemoBundle\Security\User\Provider;
+
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException,
+    Symfony\Component\Security\Core\Exception\UnsupportedUserException,
+    Symfony\Component\Security\Core\User\UserProviderInterface,
+    Symfony\Component\Security\Core\User\UserInterface,
+    Symfony\Component\DependencyInjection\ContainerInterface;
+
+use IMAG\LdapBundle\Manager\LdapManagerUserInterface,
+    IMAG\LdapBundle\User\LdapUserInterface;
+use FOS\UserBundle\Model\UserManagerInterface;
+
+class LdapUserProvider implements UserProviderInterface
+{
+    /**
+     * @var \IMAG\LdapBundle\Manager\LdapManagerUserInterface
+     */
+    private $ldapManager;
+
+    /**
+     * @var \FOS\UserBundle\Model\UserManagerInterface
+     */
+    protected $userManager;
+
+    /**
+     * @var \Symfony\Component\Validator\Validator
+     */
+    protected $validator;
+
+    /**
+     * Constructor
+     *
+     * @param LdapManagerUserInterface $ldapManager
+     * @param UserManagerInterface     $userManager
+     * @param Validator                $validator
+     */
+    public function __construct(LdapManagerUserInterface $ldapManager, UserManagerInterface $userManager, $validator)
+    {
+        $this->ldapManager = $ldapManager;
+        $this->userManager = $userManager;
+        $this->validator = $validator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadUserByUsername($username)
+    {
+        // Throw the exception if the username is not provided.
+        if (empty($username)) {
+            throw new UsernameNotFoundException('The username is not provided.');
+        }
+
+        // check if the user is already know to us
+        $user = $this->userManager->findUserBy(array("username" => $username));
+
+        // Throw an exception if the username is not found.
+        if(empty($user) && !$this->ldapManager->exists($username)) {
+            throw new UsernameNotFoundException(sprintf('User "%s" not found', $username));
+        }
+
+        $lm = $this->ldapManager
+            ->setUsername($username)
+            ->doPass();
+
+        if (empty($user)) {
+            $user = $this->userManager->createUser();
+            $user->setRoles($lm->getRoles());
+            $user
+                ->setUsername($lm->getUsername())
+                ->setPassword("")
+                ->setDn($lm->getDn())
+                ->setEmail($lm->getEmail());
+
+            $this->userManager->updateUser($user);
+        }
+
+        return $user;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshUser(UserInterface $user)
+    {
+        if (!$user instanceof LdapUserInterface) {
+            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_class($user)));
+        }
+
+        return $this->loadUserByUsername($user->getUsername());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsClass($class)
+    {
+        return $this->userManager->supportsClass($class);
+    }
+}
+```
+
+### Register the service
+
+Symfony needs to be told to use the created service by overriding the default
+provider in `services.xml`. Other services needed (like the `FOSUserManager`)
+or the user class to be used are passed to the constructor:
+```xml
+<service id="imag_ldap.security.user.provider" class="Acme\DemoBundle\Security\User\Provider\LdapUserProvider">
+  <argument type="service" id="imag_ldap.ldap_manager" />
+  <argument type="service" id="fos_user.user_manager" />
+  <argument type="service" id="validator" />
+  <argument>%imag_ldap.model.user_class%</argument>
+</service>
+```
+
+After flushing the cache a user is populated from the database via the user
+manager provided by the `FOSUserBundle` and authenticated by the directory. :smirk:

--- a/Resources/Docs/ldap_with_custom_user_manager.md
+++ b/Resources/Docs/ldap_with_custom_user_manager.md
@@ -156,6 +156,13 @@ imag_ldap:
   user_class: Acme\DemoBundle\Entity\User
 ```
 
+The encoder in `security.yml` needs to be set as well:
+```yml
+security:
+    encoders:
+        Acme\DemoBundle\Entity\User: plaintext
+```
+
 ### Create custom user provider service
 
 Now all that's left is the creation of a custom `LdapUserProvider` service that

--- a/Resources/Docs/security.yml
+++ b/Resources/Docs/security.yml
@@ -16,7 +16,7 @@ security:
     providers:
         ldap:
             id: imag_ldap.security.user.provider
-                
+
     encoders:
         IMAG\LdapBundle\User\LdapUser: plaintext
 
@@ -48,3 +48,5 @@ imag_ldap:
     name_attribute: cn
     user_attribute: member
 #    user_id: [ dn or username ] #Default dn
+
+#  user_class: IMAG\LdapBundle\User\LdapUser

--- a/Resources/config/security_ldap.xml
+++ b/Resources/config/security_ldap.xml
@@ -21,6 +21,7 @@
     <service id="imag_ldap.security.user.provider" class="%imag_ldap.security.user.provider.class%">
       <argument type="service" id="imag_ldap.ldap_manager" />
       <argument>%imag_ldap.authentication.bind_username_before%</argument>
+      <argument>%imag_ldap.model.user_class%</argument>
     </service>
 
     <service id="imag_ldap.ldap_connection" class="%imag_ldap.ldap_connection.class%" public="false">

--- a/User/LdapUser.php
+++ b/User/LdapUser.php
@@ -105,7 +105,7 @@ class LdapUser implements LdapUserInterface, UserInterface, EquatableInterface, 
 
     public function isEqualTo(UserInterface $user)
     {
-        if (!$user instanceof LdapUser
+        if (!$user instanceof LdapUserInterface
             || $user->getUsername() !== $this->username
             || $user->getEmail() !== $this->email
             || count(array_diff($user->getRoles(), $this->roles)) > 0

--- a/User/LdapUser.php
+++ b/User/LdapUser.php
@@ -5,7 +5,9 @@ namespace IMAG\LdapBundle\User;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 
-class LdapUser implements UserInterface, EquatableInterface, \Serializable
+use IMAG\LdapBundle\User\LdapUserInterface;
+
+class LdapUser implements LdapUserInterface, UserInterface, EquatableInterface, \Serializable
 {
     protected $username,
         $email,

--- a/User/LdapUser.php
+++ b/User/LdapUser.php
@@ -2,12 +2,9 @@
 
 namespace IMAG\LdapBundle\User;
 
-use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Security\Core\User\EquatableInterface;
-
 use IMAG\LdapBundle\User\LdapUserInterface;
 
-class LdapUser implements LdapUserInterface, UserInterface, EquatableInterface, \Serializable
+class LdapUser implements LdapUserInterface
 {
     protected $username,
         $email,
@@ -103,7 +100,7 @@ class LdapUser implements LdapUserInterface, UserInterface, EquatableInterface, 
         return null; //With ldap No credentials with stored ; Maybe forgotten the roles
     }
 
-    public function isEqualTo(UserInterface $user)
+    public function isEqualTo(\Symfony\Component\Security\Core\User\UserInterface $user)
     {
         if (!$user instanceof LdapUserInterface
             || $user->getUsername() !== $this->username

--- a/User/LdapUserInterface.php
+++ b/User/LdapUserInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace IMAG\LdapBundle\User;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\EquatableInterface;
+
+interface LdapUserInterface
+{
+    public function getEmail();
+    public function setEmail($email);
+
+    public function getDn();
+    public function setDn($dn);
+
+    public function getAttributes();
+    public function setAttributes(array $attributes);
+    public function getAttribute($name);
+
+    public function serialize();
+    public function unserialize($serialized);
+
+    public function __toString();
+}

--- a/User/LdapUserInterface.php
+++ b/User/LdapUserInterface.php
@@ -5,7 +5,7 @@ namespace IMAG\LdapBundle\User;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 
-interface LdapUserInterface
+interface LdapUserInterface extends UserInterface, EquatableInterface, \Serializable
 {
     public function getEmail();
     public function setEmail($email);
@@ -16,9 +16,6 @@ interface LdapUserInterface
     public function getAttributes();
     public function setAttributes(array $attributes);
     public function getAttribute($name);
-
-    public function serialize();
-    public function unserialize($serialized);
 
     public function __toString();
 }


### PR DESCRIPTION
By using an interface it is now possible to write custom User implementations (specifiable via a config parameter) that e.g. only rely on authentication done via LDAP. This allows an overridden LdapUserprovider to make use of a custom user manager (e.g. FOSUserBundle).

This PR is completely BC with older versions of this bundle by using your LdapUser implementation as a config default. If you find this PR useful, I could write a cookbook article explaining the specific usage. ;-)
