### PR TITLE
fix rememberme supportsClass()

### DIFF
--- a/Provider/LdapUserProvider.php
+++ b/Provider/LdapUserProvider.php
@@ -83,8 +83,7 @@ class LdapUserProvider implements UserProviderInterface
      */
     public function supportsClass($class)
     {
-        $class = new $class();
-        return ($class instanceof LdapUserInterface);
+        return is_subclass_of($class, '\IMAG\LdapBundle\User\LdapUserInterface');
     }
 
     private function simpleUser($username)

--- a/Provider/LdapUserProvider.php
+++ b/Provider/LdapUserProvider.php
@@ -83,6 +83,7 @@ class LdapUserProvider implements UserProviderInterface
      */
     public function supportsClass($class)
     {
+        $class = new $class();
         return ($class instanceof LdapUserInterface);
     }
 


### PR DESCRIPTION
La methode supportsClass($class) récupère un "string" de la class utilisé, afin que "$class instanceof LdapUserInterface)" fonctionne, il faut que $class soit une class et non un string.
Un simple $class = new $class() avant le return corrige ce problème.
