### PR TITLE
Fix ldap_free_result function's parameter

### DIFF
--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -51,7 +51,7 @@ class LdapConnection implements LdapConnectionInterface
         if ($search) {
             $entries = ldap_get_entries(self::$ress, $search);
 
-            @ldap_free_result(self::$ress);
+            @ldap_free_result($search);
 
             return is_array($entries) ? $entries : false;
         }


### PR DESCRIPTION
Provide a result_identifier resource (instead of the ldap_connect resource) to the ldap_free_result function
