### PR TITLE
Fix class name in PRE_BIND example

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ use IMAG\LdapBundle\Event\LdapUserEvent;
 /**
  * Performs logic before the user is found to LDAP
  */
-class LdapSecurityListener implements EventSubscriberInterface
+class LdapSecuritySubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents()
     {


### PR DESCRIPTION
The class in the PRE_BIND example does not match the class in the service definition.
