### PR TITLE
Update to PSR LoggerInterface

### DIFF
--- a/EventListener/LdapListener.php
+++ b/EventListener/LdapListener.php
@@ -5,7 +5,7 @@ namespace IMAG\LdapBundle\EventListener;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface,
     Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface,
     Symfony\Component\HttpFoundation\Request,
-    Symfony\Component\HttpKernel\Log\LoggerInterface,
+    Psr\Log\LoggerInterface,
     Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface,
     Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken,
     Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException,


### PR DESCRIPTION
Symfony's LoggerInterface is deprecated and will be removed in 3.0. This definition should be updated to use Psr\Log\LoggerInterface.
