### PR TITLE
Add POST_BIND events to authentication provider

### DIFF
--- a/Event/LdapEvents.php
+++ b/Event/LdapEvents.php
@@ -5,4 +5,5 @@ namespace IMAG\LdapBundle\Event;
 final class LdapEvents
 {
     const PRE_BIND = 'imag_ldap.security.authentication.pre_bind';
+    const POST_BIND = 'imag_ldap.security.authentication.post_bind';
 }

--- a/Event/LdapTokenEvent.php
+++ b/Event/LdapTokenEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace IMAG\LdapBundle\Event;
+
+use IMAG\LdapBundle\Authentication\Token\LdapToken;
+use Symfony\Component\EventDispatcher\Event;
+
+class LdapTokenEvent extends Event
+{
+    private $token;
+
+    public function __construct(LdapToken $token)
+    {
+        $this->token = $token;
+    }
+
+    public function getToken()
+    {
+        return $this->token;
+    }
+}


### PR DESCRIPTION
Adding POST_BIND events allows you to easily do last-minute checks before the user is fully authenticated. For example, if your application requires that a user have a certain role, a POST_BIND event could be used to pass the token to the SecurityContext and verify that the role is present.
