### PR TITLE
Support all parameters for ldap_search, especially sizelimit and timelimit

### DIFF
--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -35,6 +35,10 @@ class LdapConnection implements LdapConnectionInterface
         }
 
         $attrs = isset($params['attrs']) ? $params['attrs'] : array();
+        $params['attrsonly'] = isset($params['attrsonly']) ? $params['attrsonly'] : 0;
+        $params['sizelimit'] = isset($params['sizelimit']) ? $params['sizelimit'] : 0;
+        $params['timelimit'] = isset($params['timelimit']) ? $params['timelimit'] : 0;
+        $params['deref'] = isset($params['deref']) ? $params['deref'] : LDAP_DEREF_NEVER;
 
         $this->info(
             sprintf('ldap_search base_dn %s, filter %s',
@@ -46,7 +50,11 @@ class LdapConnection implements LdapConnectionInterface
             $this->ress,
             $params['base_dn'],
             $params['filter'],
-            $attrs
+            $attrs,
+            $params['attrsonly'],
+            $params['sizelimit'],
+            $params['timelimit'],
+            $params['deref']
         );
 
         if ($search) {


### PR DESCRIPTION
My LDAP service is kind enough to honor the sizelimit and timelimit parameters, so this PR may be useful to others.  These extra 4 parameters were added in PHP 4.0.2, so I think it is a safe addition to LdapBundle.

Reference: http://us1.php.net/manual/en/function.ldap-search.php
