### PR TITLE
Check LDAP attribute exists before accessing it.

### DIFF
--- a/Manager/LdapManagerUser.php
+++ b/Manager/LdapManagerUser.php
@@ -207,9 +207,11 @@ class LdapManagerUser implements LdapManagerUserInterface
             ));
 
         for ($i = 0; $i < $entries['count']; $i++) {
-            array_push($tab, sprintf('ROLE_%s',
-                                     self::slugify($entries[$i][$this->params['role']['name_attribute']][0])
-            ));
+            if (isset($entries[$i][$this->params['role']['name_attribute']][0])) {
+                array_push($tab, sprintf('ROLE_%s',
+                                         self::slugify($entries[$i][$this->params['role']['name_attribute']][0])
+                ));
+            }
         }
 
         $this->ldapUser['roles'] = $tab;


### PR DESCRIPTION
We're using the imag_ldap role configuration to load a role from our LDAP directory into $user->roles.

As the code stands now, it expects that all people in the LDAP directory have the 'name_attribute' attribute and attempts to add this regardless.

The isset() check prevents a PHP Notice when this scenario arises.
