### PR TITLE
adding ldap_errno and ldap_error, useful for debugging and more verbose

### DIFF
--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -21,6 +21,32 @@ class LdapConnection implements LdapConnectionInterface
         $this->logger = $logger;
     }
 
+    /**
+     * @return int|null
+     *
+     * @see https://wiki.servicenow.com/index.php?title=LDAP_Error_Codes
+     */
+    public function getErrno()
+    {
+        if (!$this->ress) {
+            return null;
+        }
+
+        return ldap_errno($this->ress);
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getError()
+    {
+        if (!$this->ress) {
+            return null;
+        }
+
+        return ldap_error($this->ress);
+    }
+
     public function search(array $params)
     {
         $this->connect();

--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -22,13 +22,16 @@ class LdapConnection implements LdapConnectionInterface
     }
 
     /**
-     * @return int|null
+     * @param resource|null $resource
+     *
+     * @return null|string
      *
      * @see https://wiki.servicenow.com/index.php?title=LDAP_Error_Codes
      */
-    public function getErrno()
+    public function getErrno($resource = null)
     {
-        if (!$this->ress) {
+        $resource = $resource ?: $this->ress;
+        if (!$resource) {
             return null;
         }
 
@@ -36,11 +39,14 @@ class LdapConnection implements LdapConnectionInterface
     }
 
     /**
+     * @param resource|null $resource
+     *
      * @return null|string
      */
-    public function getError()
+    public function getError($resource = null)
     {
-        if (!$this->ress) {
+        $resource = $resource ?: $this->ress;
+        if (!$resource) {
             return null;
         }
 

--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -35,7 +35,7 @@ class LdapConnection implements LdapConnectionInterface
             return null;
         }
 
-        return ldap_errno($this->ress);
+        return ldap_errno($resource);
     }
 
     /**
@@ -50,7 +50,7 @@ class LdapConnection implements LdapConnectionInterface
             return null;
         }
 
-        return ldap_error($this->ress);
+        return ldap_error($resource);
     }
 
     public function search(array $params)


### PR DESCRIPTION
IMO adding `ldap_errno` and `ldap_error` will help developers with debugging issue with LDAP and with knowledge of errno and error difference exception can be thrown
