### PR TITLE
Make security token available in LdapUserEvent

### DIFF
--- a/Event/LdapUserEvent.php
+++ b/Event/LdapUserEvent.php
@@ -5,16 +5,19 @@ namespace IMAG\LdapBundle\Event;
 use Symfony\Component\EventDispatcher\Event;
 
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 use IMAG\LdapBundle\User\LdapUserInterface;
 
 class LdapUserEvent extends Event
 {
     private $user;
+    private $token;
 
-    public function __construct(LdapUserInterface $user)
+    public function __construct(LdapUserInterface $user, TokenInterface $token)
     {
         $this->user = $user;
+	$this->token = $token;
     }
 
     public function getUser()
@@ -27,5 +30,16 @@ class LdapUserEvent extends Event
         $this->user = $user;
 
         return $this;
+    }
+
+    public function getToken()
+    {
+	return $this->token;
+    }
+
+    public function setToken($token)
+    {
+	$this->token = $token;
+	return $this;
     }
 }

--- a/Provider/LdapAuthenticationProvider.php
+++ b/Provider/LdapAuthenticationProvider.php
@@ -96,7 +96,7 @@ class LdapAuthenticationProvider implements AuthenticationProviderInterface
     private function ldapAuthenticate(LdapUserInterface $user, TokenInterface $token)
     {
         if (null !== $this->dispatcher) {
-            $userEvent = new LdapUserEvent($user);
+	    $userEvent = new LdapUserEvent($user, $token);
             try {
                 $this->dispatcher->dispatch(LdapEvents::PRE_BIND, $userEvent);
             } catch (AuthenticationException $expt) {
@@ -114,7 +114,7 @@ class LdapAuthenticationProvider implements AuthenticationProviderInterface
             }
 
             if (null !== $this->dispatcher) {
-                $userEvent = new LdapUserEvent($user);
+		$userEvent = new LdapUserEvent($user, $token);
 
                 try {
                     $this->dispatcher->dispatch(LdapEvents::POST_BIND, $userEvent);


### PR DESCRIPTION
When binding the the `POST_BIND` event I found the need to have access to the security token.

I'm not sure if this now makes passing in the user as the first parameter redundant due to being able to access it from the token.
