### PR TITLE
Update LdapAuthenticationProvider for bind data

### DIFF
--- a/Provider/LdapAuthenticationProvider.php
+++ b/Provider/LdapAuthenticationProvider.php
@@ -149,13 +149,27 @@ class LdapAuthenticationProvider implements AuthenticationProviderInterface
      *
      * @return boolean
      */
-    private function bind(LdapUserInterface $user, TokenInterface $token)
-    {
-        $this->ldapManager
-            ->setUsername($user->getUsername())
-            ->setPassword($token->getCredentials());
-
-        return (bool)$this->ldapManager->auth();
+    private function bind(LdapUserInterface $user, TokenInterface $token)      
+    {                                                                          
+        $lm = $this->ldapManager;
+        $lm
+            ->setUsername($user->getUsername())                                
+            ->setPassword($token->getCredentials());                           
+                                                                               
+        if( !(bool)$lm->auth() ) return false;
+                                                                               
+        $user
+            ->setUsername($lm->getUsername())                                  
+            ->setEmail($lm->getEmail())                                        
+            ->setRoles($lm->getRoles())                                        
+            ->setDn($lm->getDn())                                              
+            ->setCn($lm->getCn())                                              
+            ->setAttributes($lm->getAttributes())                              
+            ->setGivenName($lm->getGivenName())                                
+            ->setSurname($lm->getSurname())                                    
+            ->setDisplayName($lm->getDisplayName())                            
+        ;                                                                      
+        return true;                                                           
     }
 
     /**


### PR DESCRIPTION
If bind_username_before config option is on, user data is not passed to token interface.  This fix refresh user data from user manager 
