### PR TITLE
Reuse bound connection to improve performance

### DIFF
--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -17,7 +17,7 @@ class LdapConnection implements LdapConnectionInterface
      * Holds a list of resources per username (username=>resource) to allow for reusing binded connections.
      * @var array
      */
-    protected $resources = [];
+    protected $resources = array();
 
     public function __construct(array $params, Logger $logger)
     {


### PR DESCRIPTION
When connecting to an LDAP server on development, I noticed the ldap_bind() function would take around 10 seconds to respond. This showed me that the ldap_open() and ldap_bind() is called 2 or 3 times in one request cycle, even for same username/password. 

I implemented this reuse of the bound resource and have been able to reduce the request time considerably. I propose to implement this. Since it is possible to bind a connection with different usernames, I am keeping a mapping of username => resource to have separate connections for different users.
