### PR TITLE
Add LDAP_OPT_RESTART option for manage the long time conection

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -41,7 +41,6 @@ class Configuration implements ConfigurationInterface
               ->booleanNode('bind_username_before')->defaultFalse()->end()
               ->scalarNode('referrals_enabled')->end()
               ->scalarNode('network_timeout')->end()
-              ->booleanNode('restart')->defaultFalse()->end()
               ->booleanNode('skip_roles')->defaultFalse()->end()
            ->end()
           ;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
               ->booleanNode('bind_username_before')->defaultFalse()->end()
               ->scalarNode('referrals_enabled')->end()
               ->scalarNode('network_timeout')->end()
+              ->booleanNode('restart')->defaultFalse()->end()
               ->booleanNode('skip_roles')->defaultFalse()->end()
            ->end()
           ;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,8 +2,8 @@
 
 namespace IMAG\LdapBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\ConfigurationInterface,
-  Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 class Configuration implements ConfigurationInterface
 {
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
               ->booleanNode('bind_username_before')->defaultFalse()->end()
               ->scalarNode('referrals_enabled')->end()
               ->scalarNode('network_timeout')->end()
+              ->scalarNode('reconnect_delay')->defaultValue('5')->end()
               ->booleanNode('skip_roles')->defaultFalse()->end()
            ->end()
           ;
@@ -88,5 +89,4 @@ class Configuration implements ConfigurationInterface
 
       return $node;
   }
-
 }

--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -54,7 +54,7 @@ class LdapConnection implements LdapConnectionInterface
 
         if (false !== $search) {
             $this->lastuse = new \DateTime();
-            $this->lastuse->add(new \DateInterval('PT'.$params['reconnect_delay'].'M'));
+            $this->lastuse->add(new \DateInterval('PT'.$this->params['reconnect_delay'].'M'));
 
             $entries = ldap_get_entries($this->ress, $search);
 
@@ -75,7 +75,7 @@ class LdapConnection implements LdapConnectionInterface
         $this->connect();
 
         $this->lastuse = new \DateTime();
-        $this->lastuse->add(new \DateInterval('PT'.$params['reconnect_delay'].'M'));
+        $this->lastuse->add(new \DateInterval('PT'.$this->params['reconnect_delay'].'M'));
 
         // According to the LDAP RFC 4510-4511, the password can be blank.
         return @ldap_bind($this->ress, $user_dn, $password);
@@ -157,7 +157,7 @@ class LdapConnection implements LdapConnectionInterface
 
         $this->ress = $ress;
         $this->lastuse = new \DateTime();
-        $this->lastuse->add(new \DateInterval('PT'.$params['reconnect_delay'].'M'));
+        $this->lastuse->add(new \DateInterval('PT'.$this->params['reconnect_delay'].'M'));
         return $this;
     }
 

--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -134,6 +134,10 @@ class LdapConnection implements LdapConnectionInterface
             ldap_set_option($ress, LDAP_OPT_PROTOCOL_VERSION, $this->params['client']['version']);
         }
 
+        if (isset($this->params['client']['restart'])) {
+            ldap_set_option($ress, LDAP_OPT_RESTART, $this->params['client']['restart']);
+        }
+
         if (isset($this->params['client']['referrals_enabled'])) {
             ldap_set_option($ress, LDAP_OPT_REFERRALS, $this->params['client']['referrals_enabled']);
         }

--- a/Manager/LdapConnection.php
+++ b/Manager/LdapConnection.php
@@ -176,6 +176,53 @@ class LdapConnection implements LdapConnectionInterface
     }
 
     /**
+     * Checks if there were an error during last ldap call
+     *
+     * @throws \IMAG\LdapBundle\Exception\ConnectionException
+     */
+    private function checkLdapError($ress = null)
+    {
+        if (0 != $code = $this->getErrno($ress)) {
+            $message = $this->getError($ress);
+            $this->err('LDAP returned an error with code ' . $code . ' : ' . $message);
+            throw new ConnectionException($message, $code);
+        }
+    }
+
+
+    /**
+     * @param resource|null $resource
+     *
+     * @return null|string
+     *
+     * @see https://wiki.servicenow.com/index.php?title=LDAP_Error_Codes
+     */
+    public function getErrno($resource = null)
+    {
+        $resource = $resource ?: $this->ress;
+        if (!$resource) {
+            return null;
+        }
+
+        return ldap_errno($resource);
+    }
+
+    /**
+     * @param resource|null $resource
+     *
+     * @return null|string
+     */
+    public function getError($resource = null)
+    {
+        $resource = $resource ?: $this->ress;
+        if (!$resource) {
+            return null;
+        }
+
+        return ldap_error($resource);
+    }
+
+    /**
      * Escape string for use in LDAP search filter.
      *
      * @link http://www.php.net/manual/de/function.ldap-search.php#90158

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ imag_ldap:
 #    referrals_enabled: true # Optional
 #    bind_username_before: true # Optional
 #    skip_roles: false # Optional
+#    reconnect_delay: 5 # Optional. Delay in minute. 5 by default.
 
   user:
     base_dn: ou=people,dc=host,dc=foo

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "jbnahan/ldap-bundle",
     "description": "LDAP Bundle for Symfony 2",
-    "homepage": "http://github.com/BorisMorel/LdapBundle",
+    "homepage": "http://github.com/macintoshplus/LdapBundle",
     "license": "CeCILL",
     "authors": [
         {
@@ -36,6 +36,9 @@
     "support": {
         "irc": "irc://irc.freenode.org/sf-grenoble"
     },
+    "conflict": {
+        "imag/ldap-bundle": "*"
+    },
     "require": {
         "php": ">=5.3.3",
         "ext-ldap": "*",
@@ -45,5 +48,5 @@
         "psr-0": { "IMAG\\LdapBundle": "" }
     },
 
-    "target-dir": "IMAG/LdapBundle"
+    "target-dir": "JbNahan/LdapBundle"
 }

--- a/composer.json
+++ b/composer.json
@@ -48,5 +48,5 @@
         "psr-0": { "IMAG\\LdapBundle": "" }
     },
 
-    "target-dir": "JbNahan/LdapBundle"
+    "target-dir": "jbnahan/LdapBundle"
 }

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
     "conflict": {
         "imag/ldap-bundle": "*"
     },
+    "replace": {
+        "imag/ldap-bundle": "*"
+    },
     "require": {
         "php": ">=5.3.3",
         "ext-ldap": "*",

--- a/composer.json
+++ b/composer.json
@@ -51,5 +51,5 @@
         "psr-0": { "IMAG\\LdapBundle": "" }
     },
 
-    "target-dir": "jbnahan/LdapBundle"
+    "target-dir": "IMAG/LdapBundle"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "imag/ldap-bundle",
+    "name": "jbnahan/ldap-bundle",
     "description": "LDAP Bundle for Symfony 2",
     "homepage": "http://github.com/BorisMorel/LdapBundle",
     "license": "CeCILL",
@@ -26,6 +26,11 @@
             "name": "Shiroyuki",
             "role": "Fork Maintainer",
             "homepage": "https://github.com/shiroyuki"
+        },
+        {
+            "name": "MacintoshPlus",
+            "role": "Fork Maintainer",
+            "homepage": "https://github.com/macintoshplus"
         }
     ],
     "support": {


### PR DESCRIPTION
Hi,

I added the LDAP option `LDAP_OPT_RESTART` in the configuration file.

I use the bundle in a RabbitMQ consumer for get informations of user from a LDAP. But after a time, the `ldap_search` return `UsernameNotFoundException` because the connection et closed.
The connection is considered open because the resource variable is not null.

The problem is easily solved by this option. The connection is automatically restarted and ready.

Interested by this option ?
