### PR TITLE
Dissociate roles from groups

### DIFF
--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -12,7 +12,7 @@ namespace IMAG\LdapBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\Security;
 
 class DefaultController extends Controller
 {
@@ -21,7 +21,7 @@ class DefaultController extends Controller
         $error = $this->getAuthenticationError();
 
         return $this->render('IMAGLdapBundle:Default:login.html.twig', array(
-            'last_username' => $this->get('request')->getSession()->get(SecurityContext::LAST_USERNAME),
+            'last_username' => $this->get('request')->getSession()->get(Security::LAST_USERNAME),
             'error'         => $error,
             'token'         => $this->generateToken(),
         ));
@@ -29,11 +29,11 @@ class DefaultController extends Controller
 
     protected function getAuthenticationError()
     {
-        if ($this->get('request')->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            return $this->get('request')->attributes->get(SecurityContext::AUTHENTICATION_ERROR);
+        if ($this->get('request')->attributes->has(Security::AUTHENTICATION_ERROR)) {
+            return $this->get('request')->attributes->get(Security::AUTHENTICATION_ERROR);
         }
 
-        return $this->get('request')->getSession()->get(SecurityContext::AUTHENTICATION_ERROR);
+        return $this->get('request')->getSession()->get(Security::AUTHENTICATION_ERROR);
     }
 
     protected function generateToken()

--- a/EventListener/LdapListener.php
+++ b/EventListener/LdapListener.php
@@ -8,8 +8,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface,
     Psr\Log\LoggerInterface,
     Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface,
     Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken,
+    Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface,
     Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException,
-    Symfony\Component\Security\Core\SecurityContextInterface,
+    Symfony\Component\Security\Core\Security,
     Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface,
     Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface,
     Symfony\Component\Security\Http\Firewall\AbstractAuthenticationListener,
@@ -19,7 +20,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface,
 
 class LdapListener extends AbstractAuthenticationListener
 {
-    public function __construct(SecurityContextInterface $securityContext,
+    public function __construct(TokenStorageInterface $tokenStorage,
                                 AuthenticationManagerInterface $authenticationManager,
                                 SessionAuthenticationStrategyInterface $sessionStrategy,
                                 HttpUtils $httpUtils,
@@ -32,7 +33,7 @@ class LdapListener extends AbstractAuthenticationListener
                                 CsrfProviderInterface $csrfProvider = null)
     {
         parent::__construct(
-            $securityContext,
+            $tokenStorage,
             $authenticationManager,
             $sessionStrategy,
             $httpUtils,
@@ -86,7 +87,7 @@ class LdapListener extends AbstractAuthenticationListener
         $username = trim($request->get($this->options['username_parameter'], null, true));
         $password = $request->get($this->options['password_parameter'], null, true);
 
-        $request->getSession()->set(SecurityContextInterface::LAST_USERNAME, $username);
+        $request->getSession()->set(Security::LAST_USERNAME, $username);
 
         return $this->authenticationManager->authenticate(new UsernamePasswordToken($username, $password, $this->providerKey));
     }

--- a/Manager/LdapManagerUser.php
+++ b/Manager/LdapManagerUser.php
@@ -274,18 +274,12 @@ class LdapManagerUser implements LdapManagerUserInterface
         }
 
         foreach ($this->params['roles'] as $role => $principals) {
-            $addRole = false;
-            if (isset($principals['users'])) {
-                foreach ($principals['users'] as $user) {
-                    if ($user === $this->username) $addRole = true;
-                }
+            if (
+                (isset($principals['users']) and in_array($this->username, $principals['users'])) or
+                (isset($principals['groups'])) and !empty(array_intersect($this->ldapUser['groups'], $principals['groups']))
+            ) {
+                array_push($this->ldapUser['roles'], $role);
             }
-            if (isset($principals['groups'])) {
-                foreach ($principals['groups'] as $group) {
-                    if (in_array($group, $this->ldapUser['groups'], true)) $addRole = true;
-                }
-            }
-            if ($addRole) array_push($this->ldapUser['roles'], $role);
         }
 
         return $this;

--- a/Manager/LdapManagerUserInterface.php
+++ b/Manager/LdapManagerUserInterface.php
@@ -17,6 +17,7 @@ interface LdapManagerUserInterface
   function getGivenName();
   function getSurname();
   function getUsername();
+  function getGroups();
   function getRoles();
   function setUsername($username);
   function setPassword($password);

--- a/Provider/LdapUserProvider.php
+++ b/Provider/LdapUserProvider.php
@@ -112,6 +112,7 @@ class LdapUserProvider implements UserProviderInterface
         $ldapUser
             ->setUsername($lm->getUsername())
             ->setEmail($lm->getEmail())
+            ->setGroups($lm->getGroups())
             ->setRoles($lm->getRoles())
             ->setDn($lm->getDn())
             ->setCn($lm->getCn())

--- a/README.md
+++ b/README.md
@@ -89,19 +89,25 @@ imag_ldap:
 #    network_timeout: 10 # Optional
 #    referrals_enabled: true # Optional
 #    bind_username_before: true # Optional
+#    skip_groups: false # Optional
 #    skip_roles: false # Optional
+#    groups_as_roles: false # Optional
 
   user:
     base_dn: ou=people,dc=host,dc=foo
 #    filter: (&(foo=bar)(ObjectClass=Person)) #Optional
     name_attribute: uid
-  role:
+  groups:
     base_dn: ou=group, dc=host, dc=foo
 #    filter: (ou=group) #Optional
     name_attribute: cn
     user_attribute: member
     user_id: [ dn or username ]
-    
+  roles:
+#    ROLE_CUSTOM:
+#      users:  [ 'username', ... ] # Optional
+#      groups: [ 'groupname', ... ] # Optional
+
 #  user_class: IMAG\LdapBundle\User\LdapUser # Optional
 ```
 

--- a/Resources/Docs/security.yml
+++ b/Resources/Docs/security.yml
@@ -34,7 +34,9 @@ imag_ldap:
 #    network_timeout:
 #    referrals_enabled:
 #    bind_username_before:
+#    skip_groups:
 #    skip_roles:
+#    groups_as_roles:
 
   user:
     base_dn: ou=people, dc=host, dc=foo
@@ -42,11 +44,16 @@ imag_ldap:
     name_attribute: uid
 #    attributes:
 
-  role:
+  groups:
     base_dn: ou=group, dc=host, dc=foo
 #    filter: null #Optional
     name_attribute: cn
     user_attribute: member
 #    user_id: [ dn or username ] #Default dn
+
+  roles:
+#    ROLE_CUSTOM:
+#      users:  [ 'username', ... ] # Optional
+#      groups: [ 'groupname', ... ] # Optional
 
 #  user_class: IMAG\LdapBundle\User\LdapUser

--- a/Resources/config/security_ldap.xml
+++ b/Resources/config/security_ldap.xml
@@ -45,7 +45,7 @@
 
     <service id="imag_ldap.security.authentication.listener" class="%imag_ldap.security.authentication.listener.class%" public="false">
       <tag name="monolog.logger" channel="security" />
-      <argument type="service" id="security.context" />
+      <argument type="service" id="security.token_storage" />
       <argument type="service" id="security.authentication.manager" />
       <argument type="service" id="security.authentication.session_strategy" />
       <argument type="service" id="security.http_utils" />

--- a/User/LdapUser.php
+++ b/User/LdapUser.php
@@ -12,6 +12,7 @@ class LdapUser implements LdapUserInterface
         $email,
         $dn,
         $cn,
+        $groups = array(),
         $roles = array(),
         $attributes = array()        
         ;
@@ -47,6 +48,11 @@ class LdapUser implements LdapUserInterface
     {
         $this->surname = $surname;
         return $this;
+    }
+
+    public function getGroups()
+    {
+        return $this->groups;
     }
 
     public function getRoles()
@@ -125,6 +131,20 @@ class LdapUser implements LdapUserInterface
     public function setEmail($email)
     {
         $this->email = $email;
+
+        return $this;
+    }
+
+    public function setGroups(array $groups)
+    {
+        $this->groups = $groups;
+
+        return $this;
+    }
+
+    public function addGroup($group)
+    {
+        $this->groups[] = $group;
 
         return $this;
     }


### PR DESCRIPTION
It may not always be desirable or possible to equate identity management
systems (eg. LDAP) groups with applications roles.
This patch introduces a level of indirection between LDAP groups and
application roles. It is still possible to directly equate LDAP groups
to roles, thanks to the 'groups_to_roles' configuration option. But it
also becomes possible to map LDAP users and/or groups to custom roles
(defined in the configuration file).
