### PR TITLE
Made LdapManagerUser use returned username by LDAP instead of filled in

### DIFF
--- a/Manager/LdapManagerUser.php
+++ b/Manager/LdapManagerUser.php
@@ -125,7 +125,13 @@ class LdapManagerUser implements LdapManagerUserInterface
 
     public function getUsername()
     {
-        return $this->username;
+        $name_attr = $this->params['user']['name_attribute'];
+
+        if (isset($this->ldapUser[$name_attr][0])) {
+            return $this->ldapUser[$name_attr][0];
+        } else {
+            return $this->username;
+        }
     }
 
     public function getRoles()
@@ -273,7 +279,7 @@ class LdapManagerUser implements LdapManagerUserInterface
             break;
 
         case 'username':
-            return $this->username;
+            return $this->getUsername();
             break;
 
         default:


### PR DESCRIPTION
In some cases the LDAP search can be case-insenstive, but the search for groups is case-senstive. This can lead to missing roles.

With this PR the username for the group search will be the one the LDAP returned when searching for the user instead of what you filled in.
