### PR TITLE
Remove John Kary as maintainer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,6 @@
             "homepage": "https://github.com/instaclick"
         },
         {
-            "name": "John Kary",
-            "email": "john@johnkary.net",
-            "role": "Fork Maintainer",
-            "homepage": "https://github.com/johnkary"
-        },
-        {
             "name": "Shiroyuki",
             "role": "Fork Maintainer",
             "homepage": "https://github.com/shiroyuki"


### PR DESCRIPTION
I no longer use this bundle in any active projects nor maintain a fork of it.

Thanks!
:rocket: 
