### PR TITLE
Make LdapUser PHP 7.2 compliant

### DIFF
--- a/User/LdapUser.php
+++ b/User/LdapUser.php
@@ -66,7 +66,7 @@ class LdapUser implements LdapUserInterface
 
     public function getPassword()
     {
-        return null;
+        return '';
     }
 
     public function getSalt()


### PR DESCRIPTION
Avoid "hash_equals(): Expected known_string to be a string, null given" warning